### PR TITLE
Fix localization typo in Sign in page

### DIFF
--- a/src/assets/locale-en.json
+++ b/src/assets/locale-en.json
@@ -57,7 +57,7 @@
     "changePassword": "Change password",
     "oldPassword": "Old password",
     "newPassword": "New password",
-    "signin": "Sing In",
+    "signin": "Sign In",
     "registrationEmail": "E-mail (required):",
     "registrationUniversity": "University (optional):",
     "registrationGo": "Registry",


### PR DESCRIPTION
Rename 'Sing in' to 'Sign in' in English localization